### PR TITLE
Bump Golang version, fixes CVEs:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3-buster AS build
+FROM golang:1.20.4-buster AS build
 ARG VERSION="local"
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
This PR fixes the following CVEs:
* CVE-2023-24540
* CVE-2023-29400
* CVE-2023-24539