### PR TITLE
Bump Golang version, fixes CVEs:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-buster AS build
+FROM golang:1.20.5-buster AS build
 ARG VERSION="local"
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
This PR fixes the following CVEs:
* CVE-2023-29402
* CVE-2023-29403
* CVE-2023-29404
* CVE-2023-29405