### PR TITLE
Update base image to 1.20.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.6-bookworm AS build
+FROM golang:1.20.7-bookworm AS build
 ARG VERSION="local"
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
Update golang base image from `1.20.6` to `1.20.7`. Go `1.20.7` fixes a CVE:
* [CVE-2023-29409] https://nvd.nist.gov/vuln/detail/CVE-2023-29409