### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,12 +2,15 @@ name: Main
 
 on: [push, pull_request]
 
+env:
+  GO_VERSION: 1.21.3
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       # On tag, get tag version without v (e.g. v1.0.0 -> 1.0.0, v1.1.1-beta -> 1.1.1-beta)
       - name: Get tag version
         id: get_version
@@ -21,25 +24,39 @@ jobs:
           fi
           echo "Using version: $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-      # Build and test binary
       - name: Build and Test Binary
         env:
           CGO_ENABLED: 0
         run: |
+          go version
           go mod download
-          go test -test.timeout 50s 
-          GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle -ldflags="-X 'main.Version=${{ steps.get_version.outputs.VERSION }}'"
+          go test -test.timeout 50s
+          
+          for arch in amd64 arm64
+          do 
+            GOOS=linux GOARCH="$arch" go build -o "build/linux/$arch/scuttle" -ldflags="-X 'main.Version=${{ steps.get_version.outputs.VERSION }}'"
+          done
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: startsWith(github.ref, 'refs/tags/')
       # Build Docker image
       # On tag, push Docker image
       - name: Build Docker Image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v5
         with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: kvij/scuttle
           tags: latest,${{ steps.get_version.outputs.VERSION }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
-          build_args: VERSION=${{ steps.get_version.outputs.VERSION }}
+          build-args: |
+            VERSION=${{ steps.get_version.outputs.VERSION }}
+            GO_VERSION=${{ env.GO_VERSION }}
       # On tag, Pack zip of scuttle for GitHub Release
       - name: Pack
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
       # On tag, get tag version without v (e.g. v1.0.0 -> 1.0.0, v1.1.1-beta -> 1.1.1-beta)
       - name: Get tag version
         id: get_version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM golang:1.21.3-bookworm AS build
-ARG VERSION="local"
+ARG GO_VERSION=1
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:${GO_VERSION}-bookworm AS build
+
+ARG VERSION=local
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
 COPY . /app
 WORKDIR /app
 RUN go get -d
 RUN go test -test.timeout 50s 
-RUN CGO_ENABLED=0 go build -o scuttle -ldflags="-X 'main.Version=${VERSION}'"
+RUN CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" go build -o scuttle -ldflags="-X 'main.Version=${VERSION}'"
 
 FROM scratch
 COPY --from=build /app/scuttle /scuttle


### PR DESCRIPTION
-  Fix bug where GitHub release artifacts are not using the Go version as specified in the release notes and docker images.
  NOTE: For this fix the Go version is no longer maintained in the `Dockerfile` but in `.github/workflows/realease.yaml`
- Adds ARM64 build artifact and container images.
- Fixes 'docker/build-push-action' `repository` param deprication notice.
- Updates actions to latest version.
