### PR TITLE
Update Go version to 1.21.4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Main
 on: [push, pull_request]
 
 env:
-  GO_VERSION: 1.21.3
+  GO_VERSION: 1.21.4
 
 jobs:
   build-and-release:


### PR DESCRIPTION
Update Go from `1.21.3` to `1.21.4`.
Go `1.21.4` fixes a (rather irrelevant) CVE:
* [CVE-2023-45284] https://nvd.nist.gov/vuln/detail/CVE-2023-45284