### PR TITLE
Fix ARM64 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ ARG GO_VERSION=1
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:${GO_VERSION}-bookworm AS build
 
 ARG VERSION=local
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
The TARGETOS and TARGETARCH arguments are special and can't have a default assigned and also get values from BuildKit.