### PR TITLE
Update Go version to 1.21.5

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Main
 on: [push, pull_request]
 
 env:
-  GO_VERSION: 1.21.4
+  GO_VERSION: 1.21.5
 
 jobs:
   build-and-release:


### PR DESCRIPTION
Update Go from `1.21.4` to `1.21.5`.
Go `1.21.5` fixes CVEs:
* [CVE-2023-39326] https://nvd.nist.gov/vuln/detail/CVE-2023-39326
* [CVE-2023-45283] https://nvd.nist.gov/vuln/detail/CVE-2023-45283