### PR TITLE
Update Go version to 1.21.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Main
 on: [push, pull_request]
 
 env:
-  GO_VERSION: 1.21.5
+  GO_VERSION: 1.22.1
 
 jobs:
   build-and-release:


### PR DESCRIPTION
Update Go from `1.21.5` to `1.22.1`.
Go `1.22.1` fixes CVEs:
* [CVE-2024-24783] https://nvd.nist.gov/vuln/detail/CVE-2024-24783
* [CVE-2023-45290] https://nvd.nist.gov/vuln/detail/CVE-2023-45290
* [CVE-2023-45289] https://nvd.nist.gov/vuln/detail/CVE-2023-45289