### PR TITLE
Update Go version to 1.22.3

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Main
 on: [push, pull_request]
 
 env:
-  GO_VERSION: 1.22.1
+  GO_VERSION: 1.22.3
 
 jobs:
   build-and-release:


### PR DESCRIPTION
Update Go from `1.22.1` to `1.22.3`.

Go `1.22.3` fixes CVEs:
* [CVE-2024-24788] https://nvd.nist.gov/vuln/detail/CVE-2024-24788
* [CVE-2023-45288] https://nvd.nist.gov/vuln/detail/CVE-2023-45288