### PR TITLE
Update Go version to 1.22.4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Main
 on: [push, pull_request]
 
 env:
-  GO_VERSION: 1.22.3
+  GO_VERSION: 1.22.4
 
 jobs:
   build-and-release:


### PR DESCRIPTION
Update Go from `1.22.3` to `1.22.4`.
Go `1.22.4` fixes CVEs:
* [CVE-2024-24790] https://nvd.nist.gov/vuln/detail/CVE-2024-24790